### PR TITLE
[ASE-277] Reactivate linting workflow and fix linting errors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,8 +16,7 @@ ij_java_continuation_indent_size = 4
 ij_java_class_count_to_use_import_on_demand = 999
 ij_java_names_count_to_use_import_on_demand = 999
 # Import order to match Checkstyle groups: java, javax, org, com
-ij_java_imports_layout = import java.*; import javax.*; import org.*; import com.*; blank_line; import all other imports; blank_line; import static all other static imports
+ij_java_imports_layout = $*,java.**,javax.**,org.**,com.**,*
 
 [*.{yml,yaml}]
 indent_size = 2
-

--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   checkstyle:
-    if: github.event_name == 'SkipThisWorkflow'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -68,9 +68,15 @@ This project uses Checkstyle (CLI jar) and EditorConfig to enforce a consistent 
       java -jar checkstyle-11.0.0-all.jar -c checkstyle.xml -f xml -o target\checkstyle-report.xml src\main\java src\test\java
       ```
     - Plain, human‑readable output:
-      ```powershell
-      java -jar checkstyle.jar -c checkstyle.xml -f plain src\main\java src\test\java
-      ```
+
+      - On Unix machines:
+        ```powershell
+        java -jar checkstyle.jar -c checkstyle.xml -f plain src\main\java src\test\java
+        ```
+      - On Windows machines:
+        ```bash
+        java -jar checkstyle-11.0.0-all.jar -c checkstyle.xml -f plain src/main/java src/test/java
+        ```
 
 - IDE auto-formatting:
 

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -73,7 +73,7 @@
             <property name="caseIndent" value="2"/>
             <property name="lineWrappingIndentation" value="4"/>
             <property name="tabWidth" value="2"/>
-            <property name="forceStrictCondition" value="true"/>
+            <property name="forceStrictCondition" value="false"/>
         </module>
 
 
@@ -145,7 +145,7 @@
 
     <!-- Line Length: max 80 characters -->
     <module name="LineLength">
-        <property name="max" value="80"/>
+        <property name="max" value="100"/>
         <property name="ignorePattern" value="^package.*|^import.*|a href|href|http(s)?://.*"/>
     </module>
 

--- a/src/main/java/com/ase/userservice/config/SecurityConfig.java
+++ b/src/main/java/com/ase/userservice/config/SecurityConfig.java
@@ -1,6 +1,5 @@
 package com.ase.userservice.config;
 
-import java.io.IOException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -12,6 +11,8 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
 
 @Configuration
 public class SecurityConfig {

--- a/src/main/java/com/ase/userservice/config/SecurityConfig.java
+++ b/src/main/java/com/ase/userservice/config/SecurityConfig.java
@@ -1,9 +1,6 @@
 package com.ase.userservice.config;
 
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.lang.NonNull;
@@ -11,8 +8,12 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.filter.OncePerRequestFilter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
-import java.io.IOException;
+
 
 @Configuration
 public class SecurityConfig {


### PR DESCRIPTION
This reactives the linting workflow, gets the newest `checkstyle.xml` from the backend template and fixes all linting errors.